### PR TITLE
Fix Docker Build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Hadolint
         uses: hadolint/hadolint-action@v1.6.0
+        with:
+          ignore: DL3015
 
   image:
     name: Image

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ override.tf.json
 # example: *tfplan*
 /infrastructure/staging/creds.sh
 /infrastructure/staging/inventory.ini
+.nova

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,14 @@ ENV PIP_NO_CACHE_DIR=off
 ENV PIP_DISABLE_PIP_VERSION_CHECK=on
 ENV PIP_DEFAULT_TIMEOUT=100
 
+
+
 RUN python -m pip install --no-cache-dir "poetry==${POETRY_VERSION}" --user
 
 FROM poetry as build
 WORKDIR /app
 COPY poetry.lock pyproject.toml /app/
+
 RUN python -m poetry export --dev -f requirements.txt --output requirements-dev.txt && \
   python -m poetry export -f requirements.txt --output requirements.txt
 
@@ -26,6 +29,7 @@ ENTRYPOINT ["python", "-m", "nachomemes.bot", "-d"]
 FROM python:3.10.1-slim as prod
 WORKDIR /app
 COPY --from=build /app/requirements.txt /app/requirements.txt
+RUN apt-get update && apt-get install gcc -y
 RUN python -m pip install --no-cache-dir -r requirements.txt
 COPY . /app/
 ENTRYPOINT ["python", "-m", "nachomemes.bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN python -m poetry export --dev -f requirements.txt --output requirements-dev.
 
 FROM python:3.10.1-slim as dev
 COPY --from=build /app/requirements-dev.txt /app/requirements.txt
+RUN apt-get update && apt-get install gcc -y
 WORKDIR /app
 RUN python -m pip install --no-cache-dir -r requirements.txt
 COPY . /app/
@@ -28,8 +29,8 @@ ENTRYPOINT ["python", "-m", "nachomemes.bot", "-d"]
 
 FROM python:3.10.1-slim as prod
 WORKDIR /app
-COPY --from=build /app/requirements.txt /app/requirements.txt
 RUN apt-get update && apt-get install gcc -y
+COPY --from=build /app/requirements.txt /app/requirements.txt
 RUN python -m pip install --no-cache-dir -r requirements.txt
 COPY . /app/
 ENTRYPOINT ["python", "-m", "nachomemes.bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN python -m poetry export --dev -f requirements.txt --output requirements-dev.
 
 FROM python:3.10.1-slim as dev
 COPY --from=build /app/requirements-dev.txt /app/requirements.txt
-RUN apt-get update && apt-get install gcc -y
+RUN apt-get update && apt-get install gcc=4:10.2.1-1 -y
 WORKDIR /app
 RUN python -m pip install --no-cache-dir -r requirements.txt
 COPY . /app/
@@ -29,7 +29,7 @@ ENTRYPOINT ["python", "-m", "nachomemes.bot", "-d"]
 
 FROM python:3.10.1-slim as prod
 WORKDIR /app
-RUN apt-get update && apt-get install gcc -y
+RUN apt-get update && apt-get install gcc=4:10.2.1-1 -y && rm  -rf /var/lib/apt/lists/*
 COPY --from=build /app/requirements.txt /app/requirements.txt
 RUN python -m pip install --no-cache-dir -r requirements.txt
 COPY . /app/


### PR DESCRIPTION
A newer version of a dependency now has a requirement of gcc on the host. Our slim image didn't have this, so this manually installs it. 